### PR TITLE
Shrink TCP buffers before closing sockets

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,7 @@
+CompileFlags:
+  CompilationDatabase: build/       # Search build/ directory for compile_commands.json
+
+  # remove command line options clangd doesn't like.
+  Remove:
+    - '-Werror'
+    - '-mtp=soft'

--- a/source/console.c
+++ b/source/console.c
@@ -26,6 +26,7 @@ void console_print(const char* fmt, ...)
     if (should_log)
     {
         stdout = stderr = fopen("/config/sys-ftpd/logs/ftpd.log", "a");
+        setvbuf(stdout, NULL, _IONBF, 0);
         va_list ap;
         va_start(ap, fmt);
         vprintf(fmt, ap);
@@ -39,6 +40,7 @@ void debug_print(const char* fmt, ...)
     if (should_log)
     {
         stdout = stderr = fopen("/config/sys-ftpd/logs/ftpd.log", "a");
+        setvbuf(stdout, NULL, _IONBF, 0);
 #ifdef ENABLE_LOGGING
         va_list ap;
         va_start(ap, fmt);

--- a/source/ftp.c
+++ b/source/ftp.c
@@ -1135,7 +1135,7 @@ ftp_send_response_buffer(ftp_session_t* session,
 
     /* send response */
     to_send = len;
-    console_print(GREEN "%s" RESET, buffer);
+    console_print(GREEN "%.*s" RESET, (int)len, buffer);
     rc = send(session->cmd_fd, buffer, to_send, 0);
     if (rc < 0)
     {

--- a/source/ftp.c
+++ b/source/ftp.c
@@ -381,6 +381,52 @@ ftp_set_socket_options(int fd)
     return 0;
 }
 
+/// Even though we set linger to 0 seconds,
+/// the OS still takes several seconds to clean up socket memory after close(),
+/// leading to OOM-induced errors when transferring directory trees.
+/// If we shrink socket buffers to 1 byte before closing, we can greatly delay these errors.
+static int
+ftp_shrink_socket(int fd)
+{
+    int rc;
+    int ret = 0;
+
+    int stub_buffersize = 1;
+
+    /* stub out receive buffer */
+    rc = setsockopt(fd, SOL_SOCKET, SO_RCVBUF,
+                    &stub_buffersize, sizeof(stub_buffersize));
+    if (rc != 0)
+    {
+        console_print(RED "ftp_shrink_socket() setsockopt: SO_RCVBUF %d %s\n" RESET, errno, strerror(errno));
+        ret = -1;
+    }
+
+    /* stub out send buffer */
+    rc = setsockopt(fd, SOL_SOCKET, SO_SNDBUF,
+                    &stub_buffersize, sizeof(stub_buffersize));
+    if (rc != 0)
+    {
+        console_print(RED "ftp_shrink_socket() setsockopt: SO_SNDBUF %d %s\n" RESET, errno, strerror(errno));
+        ret = -1;
+    }
+
+    return ret;
+}
+
+typedef enum SocketCloseType
+{
+    SocketListen,
+    SocketDisconneced = SocketListen,
+    SocketConnected,
+} SocketCloseType;
+
+typedef enum ShouldShrinkSocket
+{
+    ShrinkNo,
+    ShrinkYes,
+} ShouldShrinkSocket;
+
 /*! close a socket
  *
  *  @param[in] fd        socket to close
@@ -388,7 +434,8 @@ ftp_set_socket_options(int fd)
  */
 static void
 ftp_closesocket(int fd,
-                bool connected)
+                SocketCloseType connected,
+                ShouldShrinkSocket shrink)
 {
     int rc;
     struct sockaddr_in addr;
@@ -397,7 +444,8 @@ ftp_closesocket(int fd,
 
     //  console_print("0x%X\n", socketGetLastBsdResult());
 
-    if (connected)
+    // nothing to shutdown for a listen-only socket
+    if (connected == SocketConnected)
     {
         /* get peer address and print */
         rc = getpeername(fd, (struct sockaddr*)&addr, &addrlen);
@@ -434,6 +482,16 @@ ftp_closesocket(int fd,
         console_print(RED "setsockopt: SO_LINGER %d %s\n" RESET,
                       errno, strerror(errno));
 
+    // pasv_fd -> data_fd have ftp_set_socket_options() called and need to be shrunken.
+    // listenfd -> cmd_fd do not need to be shrunken.
+    // I placed this call *after* shutdown(), so if the client is still sending data
+    // we won't fetch 1 byte at a time over the network.
+    if (shrink == ShrinkYes)
+    {
+        // Do we need to shrink listen sockets? I don't care enough to test.
+        ftp_shrink_socket(fd);
+    }
+
     /* close socket */
     rc = close(fd);
     if (rc != 0)
@@ -449,7 +507,7 @@ ftp_session_close_cmd(ftp_session_t* session)
 {
     /* close command socket */
     if (session->cmd_fd >= 0)
-        ftp_closesocket(session->cmd_fd, true);
+        ftp_closesocket(session->cmd_fd, SocketConnected, ShrinkNo);
     session->cmd_fd = -1;
 }
 
@@ -467,7 +525,7 @@ ftp_session_close_pasv(ftp_session_t* session)
                       inet_ntoa(session->pasv_addr.sin_addr),
                       ntohs(session->pasv_addr.sin_port));
 
-        ftp_closesocket(session->pasv_fd, false);
+        ftp_closesocket(session->pasv_fd, SocketListen, ShrinkYes);
     }
 
     session->pasv_fd = -1;
@@ -482,7 +540,7 @@ ftp_session_close_data(ftp_session_t* session)
 {
     /* close data connection */
     if (session->data_fd >= 0 && session->data_fd != session->cmd_fd)
-        ftp_closesocket(session->data_fd, true);
+        ftp_closesocket(session->data_fd, SocketConnected, ShrinkYes);
     session->data_fd = -1;
 
     /* clear send/recv flags */
@@ -1257,7 +1315,7 @@ ftp_session_new(int listen_fd)
     if (session == NULL)
     {
         console_print(RED "failed to allocate session\n" RESET);
-        ftp_closesocket(new_fd, true);
+        ftp_closesocket(new_fd, SocketConnected, ShrinkNo);
         return -1;
     }
 
@@ -1339,7 +1397,8 @@ ftp_session_accept(ftp_session_t* session)
         rc = ftp_set_socket_nonblocking(new_fd);
         if (rc != 0)
         {
-            ftp_closesocket(new_fd, true);
+            // pasv_fd has large buffers so new_fd will inherit them, and must be shrunken.
+            ftp_closesocket(new_fd, SocketConnected, ShrinkYes);
             ftp_session_set_state(session, COMMAND_STATE, CLOSE_PASV | CLOSE_DATA);
             ftp_send_response(session, 425, "Failed to establish connection\r\n");
             return -1;
@@ -1388,7 +1447,7 @@ ftp_session_connect(ftp_session_t* session)
     rc = ftp_set_socket_options(session->data_fd);
     if (rc != 0)
     {
-        ftp_closesocket(session->data_fd, false);
+        ftp_closesocket(session->data_fd, SocketDisconneced, ShrinkYes);
         session->data_fd = -1;
         return -1;
     }
@@ -1406,7 +1465,7 @@ ftp_session_connect(ftp_session_t* session)
         if (errno != EINPROGRESS)
         {
             console_print(RED "connect: %d %s\n" RESET, errno, strerror(errno));
-            ftp_closesocket(session->data_fd, false);
+            ftp_closesocket(session->data_fd, SocketDisconneced, ShrinkYes);
             session->data_fd = -1;
             return -1;
         }
@@ -2040,7 +2099,7 @@ void ftp_exit(void)
 
     /* stop listening for new clients */
     if (listenfd >= 0)
-        ftp_closesocket(listenfd, false);
+        ftp_closesocket(listenfd, SocketListen, ShrinkNo);
 
     /* deinitialize socket driver */
     console_render();

--- a/source/ftp.c
+++ b/source/ftp.c
@@ -48,7 +48,7 @@
 #define CMD_BUFFERSIZE 0x1000
 
 int LISTEN_PORT;
-//#define LISTEN_PORT 5000
+// #define LISTEN_PORT 5000
 #ifdef _3DS
 #    define DATA_PORT (LISTEN_PORT + 1)
 #else
@@ -195,12 +195,14 @@ static ftp_command_t ftp_commands[] =
 /*! ftp command */
 #define FTP_COMMAND(x) \
     {                  \
-#        x, x,         \
+        #x,            \
+        x,             \
     }
 /*! ftp alias */
 #define FTP_ALIAS(x, y) \
     {                   \
-#        x, y,          \
+        #x,             \
+        y,              \
     }
         FTP_COMMAND(ABOR),
         FTP_COMMAND(ALLO),
@@ -893,11 +895,17 @@ ftp_session_fill_dirent_type(ftp_session_t* session, const struct stat* st,
         session->buffersize +=
             sprintf(session->buffer + session->buffersize,
                     "%c%c%c%c%c%c%c%c%c%c %lu 3DS 3DS %lld ",
-                    S_ISREG(st->st_mode) ? '-' : S_ISDIR(st->st_mode) ? 'd' :
+                    S_ISREG(st->st_mode) ? '-' : S_ISDIR(st->st_mode) ? 'd'
+                                             :
 #if !defined(_3DS) && !defined(__SWITCH__)
-                                                                      S_ISLNK(st->st_mode) ? 'l' : S_ISCHR(st->st_mode) ? 'c' : S_ISBLK(st->st_mode) ? 'b' : S_ISFIFO(st->st_mode) ? 'p' : S_ISSOCK(st->st_mode) ? 's' :
+                                             S_ISLNK(st->st_mode)    ? 'l'
+                                             : S_ISCHR(st->st_mode)  ? 'c'
+                                             : S_ISBLK(st->st_mode)  ? 'b'
+                                             : S_ISFIFO(st->st_mode) ? 'p'
+                                             : S_ISSOCK(st->st_mode) ? 's'
+                                                                     :
 #endif
-                                                                                                                                                                                                                 '?',
+                                                                     '?',
                     st->st_mode & S_IRUSR ? 'r' : '-',
                     st->st_mode & S_IWUSR ? 'w' : '-',
                     st->st_mode & S_IXUSR ? 'x' : '-',
@@ -1842,7 +1850,7 @@ update_status(void)
     //                  inet_ntoa(serv_addr.sin_addr),
     //                ntohs(serv_addr.sin_port));
     update_free_space();
-#elif 0 //defined(__SWITCH__)
+#elif 0 // defined(__SWITCH__)
     char hostname[128];
     socklen_t addrlen = sizeof(serv_addr);
     int rc;
@@ -2108,7 +2116,7 @@ ftp_loop(void)
         apt_hook(APTHOOK_ONRESTORE, NULL);
     }
 #elif defined(__SWITCH__)
-        /* check if the user wants to exit */
+    /* check if the user wants to exit */
 #endif
 
     return LOOP_CONTINUE;
@@ -2368,12 +2376,12 @@ list_transfer(ftp_session_t* session)
 
             if (rc != 0)
             {
-#ifndef __SWITCH__
+#    ifndef __SWITCH__
                 /* an error occurred */
                 ftp_session_set_state(session, COMMAND_STATE, CLOSE_PASV | CLOSE_DATA);
                 ftp_send_response(session, 550, "unavailable\r\n");
                 return LOOP_EXIT;
-#else
+#    else
                 // probably archive bit set; list name with dummy stats
                 memset(&st, 0, sizeof(st));
                 console_print(RED "%s: type %u\n" RESET, dent->d_name, dent->d_type);
@@ -2408,7 +2416,7 @@ list_transfer(ftp_session_t* session)
                     st.st_mode = S_IFSOCK;
                     break;
                 }
-#endif
+#    endif
             }
 #endif
             /* encode \n in path */
@@ -3558,7 +3566,7 @@ FTP_DECLARE(PASV)
  */
 FTP_DECLARE(PORT)
 {
-    char *addrstr, *p, *portstr;
+    char *addrstr, *p, *portstr = NULL;
     int commas = 0, rc;
     short port = 0;
     unsigned long val;

--- a/source/util.c
+++ b/source/util.c
@@ -26,7 +26,7 @@ void initPads()
     padInitializeAny(&pad);
 }
 
-void inputPoller()
+void inputPoller(void* /* unused */)
 {
     do
     {


### PR DESCRIPTION
Fixes out-of-memory errors when transferring many files and folders (since ftp creates a new TCP connection for each directory listing or file).

Fixes #30.

- [ ] a pile of formatting changes, but they were imposed by the .vscode folder shipped in the repo.
- [ ] some build error/warning fixes, worth merging but not sure they belong in the same PR?
- [x] should I remove the mutex I added? it was part of initial debugging before i traced down the problem with printing a non-null-terminated buffer.
- [ ] .clangd is *helpful* (see also https://github.com/switchbrew/libnx/issues/719#issuecomment-4040730861), i include it in my repos, idk if you want it in yours
- [ ] "Disable console buffering" is useful for debugging, doesn't affect operation with log files off, but idk if you want it upstream

...

- [ ] probably best others test it too, it worked for me (allowed me to transfer 64 folders/files without an error) but IDK how it behaves on others' systems
  - i managed to transfer 256 folders/files, but it took multiple minutes

## Rambling

In theory, disabling linger should allow us to free up socket buffers as soon as we close a socket.
In practice libnx/hos *waits* to free socket buffers for an indeterminate time, resulting in "socket: 105 No buffer space available" when PASV tries to create a socket(). (Note that this *is* different from not closing sockets at all, since closed sockets are *eventually* freed up after several seconds, allowing new sockets to be opened.)
If we increase SOCK_BUFFERSIZE, we can even end up with socket *disconnects* where sys-ftpd sees a 0-byte recv (EOF) and prints "peer closed connection", and the PC prints "Could not read from (transfer) socket: ECONNRESET - Connection reset by peer".

Shrinking SOCK_BUFFERSIZE increases the number of directory listings or file transfers we can make before running into errors, but does not fix the problem.

A workaround I've found is to shrink the SO_RCVBUF and SO_SNDBUF buffers to 1 byte each before closing the socket. This allows transferring dozens of files without a single error. This is not a full solution to a memory leak, but since the buffers are *eventually* freed we should not hit memory constraints in normal use cases.

Of course the real solution is to switch to a protocol which *doesn't* open a new connection per file or folder... but SCP and SFTP clients require the server to run a SSH daemon (which is difficult to cram into the Switch's leftover system memory), and TFTP has a highly limited feature set.